### PR TITLE
Update infrastructure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,11 +15,14 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: dylan-lang/install-opendylan@v1
-      - uses: actions/checkout@v2
+      - uses: dylan-lang/install-opendylan@v3
+      - uses: actions/checkout@v4
+
+      - name: Download dependencies
+        run: dylan update
 
       - name: Build time-test-suite
-        run: ./dylan-compiler -build -jobs 3 time-test-suite
+        run: dylan build time-test-suite
 
       - name: Run time-test-suite
         run: _build/bin/time-test-suite

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# backup files
+*~
+*.bak
+.DS_Store
+
+# compiler build directory
+_build/
+
+# dylan tool package cache
+_packages/
+
+# package registry folder
+registry/
+
+# documentation build directory
+/documentation/build/


### PR DESCRIPTION
The previous GH Action was failing because `dylan-compiler` was not found. I have update the GH action and added some infrastructure files. 
The current test has a crash that needs to be sorted.