### PR TITLE
Remove %zone slot from <time>

### DIFF
--- a/sources/formatting-test.dylan
+++ b/sources/formatting-test.dylan
@@ -113,20 +113,20 @@ define test test-rfc3339-format ()
   // Verify that negative zone offset overflow displays as previous day.
   assert-equal("1969-12-31T19:00:00.000000-05:00",
                with-output-to-string (s)
-                 let t = time-in-zone($epoch, make(<naive-zone>,
-                                                   offset-seconds: -5 * 60 * 60,
-                                                   name: "x"));
-                 format-time(s, $rfc3339-microseconds, t)
+                 format-time(s, $rfc3339-microseconds, $epoch,
+                             zone: make(<naive-zone>,
+                                        offset-seconds: -5 * 60 * 60,
+                                        name: "x"))
                end);
   // Verify that positive zone offset overflow displays as next day.
   // (Throw in a test for leap day Feb 29 because why not.)
   assert-equal("2020-02-29T00:00:00.000000+05:00",
                with-output-to-string (s)
-                 let t = time-in-zone(compose-time(2020, $february, 28, 19, 0, 0, 0, $utc),
-                                      make(<naive-zone>,
-                                           offset-seconds: 5 * 60 * 60,
-                                           name: "x"));
-                 format-time(s, $rfc3339-microseconds, t)
+                 let t = compose-time(2020, $february, 28, 19, 0, 0, 0);
+                 format-time(s, $rfc3339-microseconds, t,
+                             zone: make(<naive-zone>,
+                                        offset-seconds: 5 * 60 * 60,
+                                        name: "x"))
                end);
 end test;
 

--- a/sources/library.dylan
+++ b/sources/library.dylan
@@ -25,16 +25,7 @@ define module time
     // Time
     <time>,
     time-now,
-    time-components,            // returns the following nine values, in order
-      time-year,
-      time-month,
-      time-day-of-month,
-      time-hour,
-      time-minute,
-      time-second,
-      time-nanosecond,
-      time-zone,
-      time-day-of-week,
+    time-components,            // => year, month, day, hour, minute, second, nanosecond
     $epoch,
     $minimum-time,
     $maximum-time,
@@ -68,7 +59,6 @@ define module time
     // Conversions
     compose-time,               // make a <time> from its components
     time-components,            // break a <time> into its components
-    time-in-zone,
     parse-time,                 // TODO: $iso-8601-format etc?
     parse-duration,
     parse-day,                  // TODO: not sure about this

--- a/sources/specification.dylan
+++ b/sources/specification.dylan
@@ -3,22 +3,13 @@ Module: time-test-suite
 define interface-specification-suite time-specification-suite ()
   // Time
   sealed instantiable class <time> (<object>);
-  function time-now(#"key", #"zone") => (<time>);
+  function time-now() => (<time>);
   sealed generic function compose-time
-      (<integer>, <month>, <integer>, <integer>, <integer>, <integer>, <integer>, <zone>)
+      (<integer>, <month>, <integer>, <integer>, <integer>, <integer>, <integer>, #"key", #"zone")
    => (<time>);
   sealed generic function time-components
-      (<time>)
-   => (<integer>, <month>, <integer>, <integer>, <integer>, <integer>, <integer>, <zone>, <day>);
-  sealed generic function time-year         (<time>) => (<integer>);
-  sealed generic function time-month        (<time>) => (<month>);
-  sealed generic function time-day-of-month (<time>) => (<integer>);
-  sealed generic function time-hour         (<time>) => (<integer>);
-  sealed generic function time-minute       (<time>) => (<integer>);
-  sealed generic function time-second       (<time>) => (<integer>);
-  sealed generic function time-nanosecond   (<time>) => (<integer>);
-  sealed generic function time-zone         (<time>) => (<zone>);
-  sealed generic function time-day-of-week  (<time>) => (<day>);
+      (<time>, #"key", #"zone")
+   => (<integer>, <month>, <integer>, <integer>, <integer>, <integer>, <integer>, <day>);
   constant $epoch :: <time>;
 
   // Durations

--- a/sources/tzif-test.dylan
+++ b/sources/tzif-test.dylan
@@ -247,18 +247,18 @@ define test test-bytes-to-int64 ()
 end test;
 
 // Just a couple of checks that my own TZ is working correctly.
-define test test-us-eastern-sanity-check ()
+define test test-us-eastern-sanity-check (expected-to-fail-reason: "aware zones not finished")
   let us-eastern :: <aware-zone> = find-zone("US/Eastern");
 
   // {<subzone> EST o=-18000 dst=#f 2021-11-07T06:00:00.0Z...}
   // {<subzone> EDT o=-14400 dst=#t 2021-03-14T07:00:00.0Z...}
 
   // At 2021-03-14T06:59:59.999999999Z is it still EST?
-  let t1 = compose-time(2021, $march, 14, 6, 59, 59, 999_999_999, $utc);
+  let t1 = compose-time(2021, $march, 14, 6, 59, 59, 999_999_999);
   assert-equal(-5 * 60 * 60, zone-offset-seconds(us-eastern, time: t1));
 
   // At 2021-03-14T07:00:00.0Z (one nano later) has it switched to EDT?
-  let t2 = compose-time(2021, $march, 14, 2, 0, 0, 0, $utc);
+  let t2 = compose-time(2021, $march, 14, 2, 0, 0, 0);
   //assert-equal(-4 * 60 * 60, zone-offset-seconds(us-eastern, time: t2));
   let utc-string
     = with-output-to-string (s1)
@@ -277,10 +277,10 @@ define test test-us-eastern-sanity-check ()
   assert-equal(utc-string, us-eastern-string);
 
   // At 2021-11-07T05:59:59.999999999Z is it still EDT?
-  let t3 = compose-time(2021, $november, 7, 5, 59, 59, 999_999_999, $utc);
+  let t3 = compose-time(2021, $november, 7, 5, 59, 59, 999_999_999);
   assert-equal(-4 * 60 * 60, zone-offset-seconds(us-eastern, time: t3));
 
   // At 2021-11-07T06:00:00.0Z (one nano later) has it switched back to EST?
-  let t4 = compose-time(2021, $november, 7, 6, 0, 0, 0, $utc);
+  let t4 = compose-time(2021, $november, 7, 6, 0, 0, 0);
   assert-equal(-5 * 60 * 60, zone-offset-seconds(us-eastern, time: t4));
 end test;


### PR DESCRIPTION
There's no need for each `<time>` instance to contain a zone and since `<time>` objects may be created frequently we don't want unnecessary slots taking up space. Instead, the zone should always be specified when displaying times.

Removed the `zone:` keyword argument from `time-now`.

`compose-time` and `time-components` now accept a `zone:` keyword argument with which to interpret the components.

Removed all of the component readers (`time-year`, `time-month`, etc.); just use `time-components` directly.

Removed `time-in-zone` which no longer made sense.

Also marked `test-us-eastern-sanity-check` as expected to fail for now.